### PR TITLE
use child_process.spawnSync to start and stop nginx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
 language: node_js
 node_js:
-  - "0.11"
-  - "0.10"
+  - "0.12"

--- a/README.md
+++ b/README.md
@@ -15,10 +15,11 @@ support all of nginx's features.
 ## Installation
 TL;DR; `npm install -g proxrox`. Nginx needs to be on the `$PATH`
 
-In order to use proxrox you will need to have Node.js, NPM and nginx installed.
-Nginx can be installed automatically for OS X users via `proxrox install`.
-Users of other operating systems currently have to install nginx manually. The
-issue tracker [contains installation instructions](https://github.com/bripkens/proxrox/issues/11)
+In order to use proxrox you will need to have Node.js (v0.12 or greater, io.js
+will probably also work), npm and nginx installed. **proxrox will not work with
+Node.js v.010.** Nginx can be installed automatically for OS X users via
+`proxrox install`. Users of other operating systems currently have to install
+nginx manually. The issue tracker [contains installation instructions](https://github.com/bripkens/proxrox/issues/11)
 for Ubuntu 14.04. Make sure that the `nginx` CLI is on the `$PATH`.
 
 ```

--- a/lib/control.js
+++ b/lib/control.js
@@ -4,12 +4,9 @@ var uuid = require('node-uuid');
 var path = require('path');
 var fs = require('fs-extra');
 var mkdirp = require('mkdirp');
-var shell = require('shelljs');
-var util = require('util');
+var childProcess = require('child_process');
 var isRelative = require('./util').isRelative;
 var configGenerator = require('./config_generator');
-
-var exec = shell.exec;
 
 exports.start = function(config) {
   // the nginx config and log files will go to a temporary location
@@ -43,9 +40,13 @@ exports.start = function(config) {
     createCertificates(tmpDir);
   }
 
-  var code = exec('nginx -c ' + configPath + ' -p ' + tmpDir).code;
-  if (code !== 0) {
-    throw new Error('Failed to start the server');
+  var spawnResult = childProcess.spawnSync('nginx',
+      ['-c', configPath, '-p', tmpDir]);
+  if (spawnResult.error) {
+    throw new Error('Failed to start the server: ' + spawnResult.error);
+  }
+  if (!spawnResult.status === 0) {
+    throw new Error('Failed to start the server.');
   }
 
   return {
@@ -53,9 +54,8 @@ exports.start = function(config) {
   };
 };
 
-
 exports.stop = function() {
-  return exec('pkill -f "nginx: master process"').code === 0;
+  childProcess.spawnSync('pkill', ['-f', 'nginx: master process']);
 };
 
 function createCertificates(tmpDir) {
@@ -86,14 +86,9 @@ function createCertificates(tmpDir) {
   );
 }
 
-function execAndCheck(cmd, silent) {
-  if (arguments.length === 1) {
-    silent = false;
-  }
-  var result = exec(cmd, {silent: silent});
-  if (result.code !== 0) {
-    var err = util.format("Command '%s' failed. Output: %s", cmd,
-      result.output);
-    throw new Error(err);
-  }
+function execAndCheck(command, silent) {
+  // passing an empty array for option stdio results in silencing the command,
+  // that is, do not echo stdout/stderr of the child process
+  var options = silent ? { stdio: [] } : {};
+  childProcess.execSync(command, options);
 }

--- a/lib/install.js
+++ b/lib/install.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var childProcess = require('child_process');
 var os = require('os');
 var Promise = require('bluebird');
 var shell = require('shelljs');
@@ -31,13 +32,16 @@ function installOnOSX() {
   }
 
   return new Promise(function(resolve, reject) {
-    shell.exec('brew update && brew install nginx --with-spdy',
-      function(code, output) {
-        if (code === 0) {
-          resolve();
+    childProcess.exec('brew update && brew install nginx --with-spdy',
+      function(error, stdout, stderr) {
+        // echo any output of install commands to our own stdout/stderr
+        console.log(stdout);
+        console.error(stderr);
+        if (error) {
+          console.error('nginx installation failed');
+          reject(error);
         } else {
-          reject(new Error('nginx installation failed with code ' + code +
-          '. The following output was produced: \n' + output));
+          resolve();
         }
       });
   });

--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
   "scripts": {
     "test": "mocha && eslint lib/*.js test/*.js bin/*.js"
   },
+  "engines" : {
+    "node" : ">=0.12"
+  },
   "author": "Ben Ripkens <bripkens.dev@gmail.com>",
   "license": "MIT",
   "dependencies": {

--- a/test/install_test.js
+++ b/test/install_test.js
@@ -7,12 +7,15 @@ var sinon = require('sinon');
 describe('install', function() {
   var install;
   var shellStub;
+  var childProcessStub;
   var osStub;
 
   beforeEach(function() {
     shellStub = {};
+    childProcessStub = {};
     osStub = {};
     install = proxyquire('../lib/install', {
+      'child_process': childProcessStub,
       shelljs: shellStub,
       os: osStub
     });
@@ -52,9 +55,9 @@ describe('install', function() {
 
       it('should fail when homebrew installation fails', function() {
         shellStub.which = sinon.stub().returns('/usr/local/bin/brew');
-        shellStub.exec = function(cmd, cb) {
+        childProcessStub.exec = function(cmd, cb) {
           expect(cmd).to.match(/brew install/);
-          process.nextTick(cb.bind(null, 1, 'precondition error'));
+          process.nextTick(cb.bind(null, new Error('precondition error')));
         };
         var reason = /precondition error/;
         return expect(install.install()).to.be.rejectedWith(reason);
@@ -62,9 +65,9 @@ describe('install', function() {
 
       it('should work when homebrew install is successful', function() {
         shellStub.which = sinon.stub().returns('/usr/local/bin/brew');
-        shellStub.exec = function(cmd, cb) {
+        childProcessStub.exec = function(cmd, cb) {
           expect(cmd).to.match(/brew install/);
-          process.nextTick(cb.bind(null, 0, 'success'));
+          process.nextTick(cb.bind(null, null));
         };
         return expect(install.install()).to.be.fulfilled;
       });


### PR DESCRIPTION
This solves #14  (only the problem of `proxrox stop` getting stuck, not the issue of killing unrelated nginx instances).

This is not complete yet, as it might be cleaner to replace every instance of shelljs.exec by node core calls instead of just some. I also think shelljs.exec does not add much value (in contrast to the other methods of shelljs, which do).

@bripkens What do you think? Should all shelljs.exec calls be replaced? I could add it to this PR.
