### PR TITLE
Add installation description for using Nginx via Docker

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -11,6 +11,7 @@ This document describes and explains the installation of the required components
 - [Installation of Nginx](#installation-of-nginx)
 	- [Install Nginx on Mac OS X](#install-nginx-on-mac-os-x)
 	- [Install Nginx on Ubuntu](#install-nginx-on-ubuntu)
+	- [Use Nginx with Docker](#use-nginx-with-docker)
 
 <!-- /TOC -->
 
@@ -84,3 +85,47 @@ In the file add the line
 Replace `<username>` with the output of `whoami` and `/path/to/nginx` with the output of `which nginx`. Further information is available via [StackOverflow](http://askubuntu.com/questions/159007/how-do-i-run-specific-sudo-commands-without-a-password).
 
 You will also need to `chown` the Nginx error log so it is accessible by your user. You can see the location of this log file when you run `nginx -V` as the `--error-log-path` configure argument's parameter.
+
+### Use Nginx with Docker
+By aliasing the `nginx` command to start a Docker container, it's also possible to run proxrox without having Nginx
+directly installed.
+
+Create a Bash script and make it executable, with the following contents:
+
+```shell
+#!/bin/bash
+
+configpath=$2
+tmpdir=$4
+echo "===> configpath: ${configpath} and tmpdir: ${tmpdir}"
+
+del_stopped(){
+  local name=$1
+  local state=$(docker inspect --format "{{.State.Running}}" $name 2>/dev/null)
+
+  if [[ "$state" == "true" ]]; then
+    docker stop $name
+    docker rm $name
+  elif [[ "$state" == "false" ]]; then
+    docker rm $name
+  fi
+}
+
+del_stopped proxrox-nginx
+
+docker run -d \
+         --restart always \
+         -v "${configpath}:/etc/nginx/nginx.conf" \
+         -v "${tmpdir}:/etc/nginx" \
+         -v "${tmpdir}:${tmpdir}" \
+         --net host \
+         --name proxrox-nginx \
+         nginx
+```
+
+Add a symbolic link to the script so it's executable from your path, e.g.:
+
+```shell
+$ ln -s <nginx-script> /usr/local/bin/nginx
+```
+

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -90,6 +90,9 @@ You will also need to `chown` the Nginx error log so it is accessible by your us
 By aliasing the `nginx` command to start a Docker container, it's also possible to run proxrox without having Nginx
 directly installed.
 
+**Note**: This option is verified to work on Linux systems. On MacOS and Windows systems your mileage may vary. On Windows you
+might need to select `process` level isolation instead of `Hyper-V` isolation level for this to work.
+
 Create a Bash script and make it executable, with the following contents:
 
 ```shell
@@ -114,7 +117,7 @@ del_stopped(){
 del_stopped proxrox-nginx
 
 docker run -d \
-         --restart always \
+         --restart on-failure \
          -v "${configpath}:/etc/nginx/nginx.conf" \
          -v "${tmpdir}:/etc/nginx" \
          -v "${tmpdir}:${tmpdir}" \
@@ -129,3 +132,6 @@ Add a symbolic link to the script so it's executable from your path, e.g.:
 $ ln -s <nginx-script> /usr/local/bin/nginx
 ```
 
+In case it is desired to configure a [root path](https://github.com/bripkens/proxrox/blob/master/CONFIGURATION.md#root),
+please make sure to add an additional volume mapping to the above script. For example to work with a root path such as
+`/home/myhome/nginx-root`, add the mapping: `-v "/home/myhome/nginx-root:/home/myhome/nginx-root" \`.


### PR DESCRIPTION
Describe how Proxrox could also be used without having to install Nginx itself directly.

Using an alias with a script this works as well. Only need to make sure the parameters are passed correctly.